### PR TITLE
fixed - return specified type for title method Languages-resource

### DIFF
--- a/src/Console/stubs/module.languages.stub
+++ b/src/Console/stubs/module.languages.stub
@@ -35,7 +35,7 @@ class Languages extends Scaffolding implements Navigable, Filtrable, Editable, V
      *
      * @return mixed
      */
-    public function title()
+    public function title(): string
     {
         return trans("administrator::module.resources.languages");
     }


### PR DESCRIPTION
when published resource for languages here was showed errors
-with command: php artisan administrator:resource:languages